### PR TITLE
Fix CLI schema dump broken import path

### DIFF
--- a/packages/playwright-json-runner/package.json
+++ b/packages/playwright-json-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-json-runner",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Extends Playwright to run tests using JSON-based test definitions.",
   "module": "dist/index.js",
   "repository": {

--- a/packages/playwright-json-runner/src/scripts/cli.ts
+++ b/packages/playwright-json-runner/src/scripts/cli.ts
@@ -9,7 +9,7 @@
  */
 
 import * as fs from "fs";
-import { testRunSchema } from "src/schemas/test-run";
+import { testRunSchema } from "../schemas/test-run";
 import zodToJsonSchema from "zod-to-json-schema";
 
 function dumpSchema() {


### PR DESCRIPTION
## Summary
- Fixed `npm run dump-schema` failing with `MODULE_NOT_FOUND` error
- Changed `src/schemas/test-run` to relative import `../schemas/test-run` in `cli.ts` so `ts-node` resolves it correctly
- Verified all 39 actions (including scroll, waitForText, clickCoordinates, waitForHidden, waitForSelector) and the `nth` locator field are present in the dumped JSON schema

## Test plan
- [x] `npm run dump-schema` runs successfully and outputs `schema.local.json`
- [x] Dumped schema contains all 39 known action types
- [x] Locator schemas include `nth` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)